### PR TITLE
Wait 3s before checking the active queue

### DIFF
--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -2,7 +2,7 @@ var _ = require('underscore')
 var createLocalStorageAdapter = require('./local-storage-adapter')
 
 var QUEUE_POLL_INTERVAL = 100
-var ACTIVE_QUEUE_EXPIRE_TIME = 5000
+var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var DEFAULT_BATCH_SIZE = 20
 var INITIAL_BACKOFF_TIME = 1000
 var BACKOFF_POLL_INTERVAL = 1000
@@ -19,9 +19,20 @@ function createQueueThat (options) {
   var queueId = Math.random() + now()
   var processInterval, backoffInterval, queueIsSending = false
 
+  /**
+   * Check after ACTIVE_QUEUE_EXPIRE_TIME in case
+   * the previous page's queue has not expired yet.
+   */
+  var initialCheckTimer = setTimeout(function () {
+    if (!activeQueueRunning()) {
+      switchActiveQueue(queueId)
+    }
+  }, ACTIVE_QUEUE_EXPIRE_TIME)
+
   queueThat.destroy = function destroy () {
     clearInterval(processInterval)
     clearInterval(backoffInterval)
+    clearTimeout(initialCheckTimer)
   }
 
   return queueThat
@@ -35,7 +46,10 @@ function createQueueThat (options) {
       log('Item(s) sent to active queue')
       return
     }
+    switchActiveQueue(queueId)
+  }
 
+  function switchActiveQueue (queueId) {
     log('Switching to queue', queueId)
     clearInterval(processInterval)
     resumeBackoff()

--- a/test/test-queue-that.js
+++ b/test/test-queue-that.js
@@ -5,7 +5,7 @@ var sinon = require('sinon')
 var proxyquire = require('proxyquireify-es3')(require)
 
 var QUEUE_POLL_INTERVAL = 100
-var ACTIVE_QUEUE_EXPIRE_TIME = 5000
+var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var INITIAL_BACKOFF_TIME = 1000
 
 describe('createQueueThat', function () {
@@ -95,6 +95,19 @@ describe('createQueueThat', function () {
         ts: now() - ACTIVE_QUEUE_EXPIRE_TIME
       })
       queueThat('A')
+      expect(adapter.setActiveQueue.callCount).to.be(1)
+    })
+
+    it('should check the active queue ACTIVE_QUEUE_EXPIRE_TIME after initialisation', function () {
+      adapter.getActiveQueue.returns({
+        id: 123,
+        ts: now() - ACTIVE_QUEUE_EXPIRE_TIME
+      })
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME - 1)
+      expect(adapter.setActiveQueue.callCount).to.be(0)
+
+      clock.tick(1)
       expect(adapter.setActiveQueue.callCount).to.be(1)
     })
 


### PR DESCRIPTION
- This addresses issue https://github.com/QubitProducts/queue-that/issues/4 where if the active queue is stopped because of a page load, the next page queue recognises that the previous queue has expired