### PR TITLE
Non polling backoff

### DIFF
--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -5,7 +5,6 @@ var QUEUE_POLL_INTERVAL = 100
 var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var DEFAULT_BATCH_SIZE = 20
 var INITIAL_BACKOFF_TIME = 1000
-var BACKOFF_POLL_INTERVAL = 1000
 
 module.exports = createQueueThat
 
@@ -44,7 +43,6 @@ function createQueueThat (options) {
 
       log('Switching to queue', queueId)
       clearInterval(processInterval)
-      resumeBackoff()
       storageAdapter.setActiveQueue(queueId)
       processInterval = setInterval(processQueue, QUEUE_POLL_INTERVAL)
     }, ACTIVE_QUEUE_EXPIRE_TIME)
@@ -56,7 +54,8 @@ function createQueueThat (options) {
     if (queueIsSending) {
       return
     }
-    if (storageAdapter.getBackoffTime() > 0) {
+
+    if (storageAdapter.getBackoffTime() > now()) {
       return
     }
 
@@ -85,28 +84,9 @@ function createQueueThat (options) {
     log(err)
     var errorCount = storageAdapter.getErrorCount() + 1
     storageAdapter.setErrorCount(errorCount)
-    storageAdapter.setBackoffTime(INITIAL_BACKOFF_TIME * Math.pow(2, errorCount - 1))
-    resumeBackoff()
-  }
-
-  function resumeBackoff () {
-    if (storageAdapter.getBackoffTime() <= 0) {
-      return
-    }
-
-    backoffInterval = setInterval(countBackoff, BACKOFF_POLL_INTERVAL)
-
+    storageAdapter.setBackoffTime(now() + INITIAL_BACKOFF_TIME * Math.pow(2, errorCount - 1))
     log('in backoff')
-    log('backoff time:', storageAdapter.getBackoffTime())
-
-    function countBackoff () {
-      log('check backoff')
-      storageAdapter.setBackoffTime(storageAdapter.getBackoffTime() - BACKOFF_POLL_INTERVAL)
-      if (storageAdapter.getBackoffTime() <= 0) {
-        log('backoff off')
-        clearInterval(backoffInterval)
-      }
-    }
+    log('backoff time:', storageAdapter.getBackoffTime() - now())
   }
 
   function activeQueueRunning () {

--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -2,7 +2,7 @@ var _ = require('underscore')
 var createLocalStorageAdapter = require('./local-storage-adapter')
 
 var QUEUE_POLL_INTERVAL = 100
-var ACTIVE_QUEUE_EXPIRE_TIME = 5000
+var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var DEFAULT_BATCH_SIZE = 20
 var INITIAL_BACKOFF_TIME = 1000
 var BACKOFF_POLL_INTERVAL = 1000
@@ -31,16 +31,23 @@ function createQueueThat (options) {
     queue.push(item)
     storageAdapter.setQueue(queue)
 
-    if (activeQueueRunning()) {
-      log('Item(s) sent to active queue')
-      return
-    }
+    /**
+     * Wait some time in case this is the only tab
+     * and the the previous page's queue may not have
+     * expired yet.
+     */
+    setTimeout(function () {
+      if (activeQueueRunning()) {
+        log('Item(s) sent to active queue')
+        return
+      }
 
-    log('Switching to queue', queueId)
-    clearInterval(processInterval)
-    resumeBackoff()
-    storageAdapter.setActiveQueue(queueId)
-    processInterval = setInterval(processQueue, QUEUE_POLL_INTERVAL)
+      log('Switching to queue', queueId)
+      clearInterval(processInterval)
+      resumeBackoff()
+      storageAdapter.setActiveQueue(queueId)
+      processInterval = setInterval(processQueue, QUEUE_POLL_INTERVAL)
+    }, ACTIVE_QUEUE_EXPIRE_TIME)
   }
 
   function processQueue () {

--- a/test/test-queue-that.js
+++ b/test/test-queue-that.js
@@ -5,7 +5,7 @@ var sinon = require('sinon')
 var proxyquire = require('proxyquireify-es3')(require)
 
 var QUEUE_POLL_INTERVAL = 100
-var ACTIVE_QUEUE_EXPIRE_TIME = 5000
+var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var INITIAL_BACKOFF_TIME = 1000
 
 describe('createQueueThat', function () {
@@ -71,35 +71,56 @@ describe('createQueueThat', function () {
     })
 
     it('should not change the active queue if the active queue hasn\'t expired', function () {
-      adapter.getActiveQueue.returns({
-        id: '123',
-        ts: now()
-      })
+      adapter.getActiveQueue = function () {
+        return {
+          id: '123',
+          ts: now()
+        }
+      }
       queueThat('A')
-      adapter.getActiveQueue.returns({
-        id: '123',
-        ts: now() - ACTIVE_QUEUE_EXPIRE_TIME + 1
-      })
+      adapter.getActiveQueue = function () {
+        return {
+          id: '123',
+          ts: now() - ACTIVE_QUEUE_EXPIRE_TIME + 1
+        }
+      }
       queueThat('A')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       expect(adapter.setActiveQueue.callCount).to.be(0)
     })
 
     it('should change the active queue if there is not an active queue defined', function () {
       queueThat('A')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       expect(adapter.setActiveQueue.callCount).to.be(1)
     })
 
-    it('should change the active queue if the active queue has expired', function () {
-      adapter.getActiveQueue.returns({
-        id: 123,
-        ts: now() - ACTIVE_QUEUE_EXPIRE_TIME
-      })
+    it('should not change the active queue until waiting ACTIVE_QUEUE_EXPIRE_TIME', function () {
       queueThat('A')
-      expect(adapter.setActiveQueue.callCount).to.be(1)
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME - 1)
+      expect(adapter.setActiveQueue.callCount).to.be(0)
+    })
+
+    it('should change the active queue if the active queue has expired', function () {
+      adapter.getActiveQueue = function () {
+        return {
+          id: 123,
+          ts: now() - ACTIVE_QUEUE_EXPIRE_TIME
+        }
+      }
+      queueThat('A')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME - 1)
+      expect(adapter.setActiveQueue.callCount).to.be(0)
     })
 
     it('should continue updating the active timestamp', function () {
       queueThat('A')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       expect(adapter.setActiveQueue.callCount).to.be(1)
       clock.tick(QUEUE_POLL_INTERVAL)
       expect(adapter.setActiveQueue.callCount).to.be(2)
@@ -109,6 +130,8 @@ describe('createQueueThat', function () {
 
     it('should not read the queue while tasks are processing', function () {
       queueThat('A')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
       expect(adapter.getQueue.callCount).to.be(2)
 
@@ -125,12 +148,16 @@ describe('createQueueThat', function () {
 
     it('should save tasks to the queue', function () {
       queueThat('A')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
       expect(adapter.setQueue.getCall(0).args[0]).to.eql(['A'])
     })
 
     it('should add tasks to the end of the queue', function () {
       adapter.getQueue.returns(['A'])
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       queueThat('B')
       clock.tick(QUEUE_POLL_INTERVAL)
       expect(adapter.setQueue.callCount).to.be(1)
@@ -143,6 +170,8 @@ describe('createQueueThat', function () {
       })
       adapter.setQueue(['A'])
       queueThat('B')
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL / 2)
       queueThat('C')
       clock.tick(QUEUE_POLL_INTERVAL / 2)
@@ -157,9 +186,13 @@ describe('createQueueThat', function () {
     })
 
     it('should not process new tasks added to the active queue until processing has finished', function () {
+
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
+
       queueThat('B')
+
       expect(options.process.callCount).to.be(1)
       expect(options.process.getCall(0).args[0]).to.eql(['A'])
 
@@ -170,7 +203,9 @@ describe('createQueueThat', function () {
 
     it('should process new tasks added to the active queue after processing', function () {
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
+
       queueThat('B')
       expect(options.process.callCount).to.be(1)
       expect(options.process.getCall(0).args[0]).to.eql(['A'])
@@ -184,7 +219,9 @@ describe('createQueueThat', function () {
 
     it('should have a default batch size of 20', function () {
       adapter.setQueue(_.range(50))
+
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
 
       expect(options.process.callCount).to.be(1)
@@ -209,6 +246,7 @@ describe('createQueueThat', function () {
       options.batchSize = 10
       adapter.setQueue(_.range(14))
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
 
       expect(options.process.callCount).to.be(1)
@@ -225,6 +263,7 @@ describe('createQueueThat', function () {
       options.batchSize = Infinity
       adapter.setQueue(_.range(1000))
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
 
       expect(options.process.callCount).to.be(1)
@@ -239,6 +278,7 @@ describe('createQueueThat', function () {
     it('should backoff exponentially on process error', function () {
       adapter.setQueue(_.range(4))
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
 
       options.process.getCall(0).args[1]('error')
@@ -258,6 +298,7 @@ describe('createQueueThat', function () {
       adapter.setBackoffTime(3000)
       adapter.setErrorCount(3)
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
 
       clock.tick(2999)
       expect(options.process.callCount).to.be(0)
@@ -282,6 +323,7 @@ describe('createQueueThat', function () {
       adapter.setErrorCount(1)
       expect(adapter.setBackoffTime.callCount).to.be(1)
       queueThat('A')
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
 
       clock.tick(3000 + QUEUE_POLL_INTERVAL)

--- a/test/test-queue-that.js
+++ b/test/test-queue-that.js
@@ -295,7 +295,7 @@ describe('createQueueThat', function () {
     })
 
     it('should use localStorage as the back off timer', function () {
-      adapter.setBackoffTime(3000)
+      adapter.setBackoffTime(ACTIVE_QUEUE_EXPIRE_TIME + now() + 3000)
       adapter.setErrorCount(3)
       queueThat('A')
       clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
@@ -308,7 +308,7 @@ describe('createQueueThat', function () {
 
       options.process.getCall(0).args[1]('error')
       expect(adapter.setErrorCount.withArgs(4).callCount).to.be(1)
-      expect(adapter.setBackoffTime.withArgs(INITIAL_BACKOFF_TIME * Math.pow(2, 3)).callCount).to.be(1)
+      expect(adapter.setBackoffTime.withArgs(now() + INITIAL_BACKOFF_TIME * Math.pow(2, 3)).callCount).to.be(1)
 
       clock.tick(INITIAL_BACKOFF_TIME * Math.pow(2, 4) + QUEUE_POLL_INTERVAL)
       expect(options.process.callCount).to.be(2)
@@ -318,20 +318,25 @@ describe('createQueueThat', function () {
       expect(adapter.setErrorCount.withArgs(0).callCount).to.be(1)
     })
 
-    it('should not poll backoff when options.process succeeds', function () {
-      adapter.setBackoffTime(3000)
+    it('should not increment backoff when options.process succeeds', function () {
+      adapter.setBackoffTime(now() + ACTIVE_QUEUE_EXPIRE_TIME + QUEUE_POLL_INTERVAL + 3000)
       adapter.setErrorCount(1)
-      expect(adapter.setBackoffTime.callCount).to.be(1)
       queueThat('A')
+
       clock.tick(ACTIVE_QUEUE_EXPIRE_TIME)
       clock.tick(QUEUE_POLL_INTERVAL)
 
       clock.tick(3000 + QUEUE_POLL_INTERVAL)
-      expect(adapter.setBackoffTime.callCount).to.be(4)
+      expect(options.process.callCount).to.be(1)
+      expect(adapter.setBackoffTime.callCount).to.be(1)
+
+      /**
+       * Success.
+       */
       options.process.getCall(0).args[1]()
 
       clock.tick(INITIAL_BACKOFF_TIME * Math.pow(2, 6))
-      expect(adapter.setBackoffTime.callCount).to.be(4)
+      expect(adapter.setBackoffTime.callCount).to.be(1)
     })
   })
 })


### PR DESCRIPTION
Addresses issue https://github.com/QubitProducts/queue-that/issues/6. Instead of polling the backoff time, just wait for the backoff date to expire and then resume processing.