### PR TITLE
Non polling backoff timer

### DIFF
--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -5,7 +5,6 @@ var QUEUE_POLL_INTERVAL = 100
 var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var DEFAULT_BATCH_SIZE = 20
 var INITIAL_BACKOFF_TIME = 1000
-var BACKOFF_POLL_INTERVAL = 1000
 
 module.exports = createQueueThat
 
@@ -17,7 +16,7 @@ function createQueueThat (options) {
 
   var storageAdapter = createLocalStorageAdapter()
   var queueId = Math.random() + now()
-  var processInterval, backoffInterval, queueIsSending = false
+  var processInterval, queueIsSending = false
 
   /**
    * Check after ACTIVE_QUEUE_EXPIRE_TIME in case
@@ -31,7 +30,6 @@ function createQueueThat (options) {
 
   queueThat.destroy = function destroy () {
     clearInterval(processInterval)
-    clearInterval(backoffInterval)
     clearTimeout(initialCheckTimer)
   }
 
@@ -52,7 +50,6 @@ function createQueueThat (options) {
   function switchActiveQueue (queueId) {
     log('Switching to queue', queueId)
     clearInterval(processInterval)
-    resumeBackoff()
     storageAdapter.setActiveQueue(queueId)
     processInterval = setInterval(processQueue, QUEUE_POLL_INTERVAL)
   }
@@ -63,7 +60,7 @@ function createQueueThat (options) {
     if (queueIsSending) {
       return
     }
-    if (storageAdapter.getBackoffTime() > 0) {
+    if (storageAdapter.getBackoffTime() > now()) {
       return
     }
 
@@ -92,28 +89,8 @@ function createQueueThat (options) {
     log(err)
     var errorCount = storageAdapter.getErrorCount() + 1
     storageAdapter.setErrorCount(errorCount)
-    storageAdapter.setBackoffTime(INITIAL_BACKOFF_TIME * Math.pow(2, errorCount - 1))
-    resumeBackoff()
-  }
-
-  function resumeBackoff () {
-    if (storageAdapter.getBackoffTime() <= 0) {
-      return
-    }
-
-    backoffInterval = setInterval(countBackoff, BACKOFF_POLL_INTERVAL)
-
-    log('in backoff')
-    log('backoff time:', storageAdapter.getBackoffTime())
-
-    function countBackoff () {
-      log('check backoff')
-      storageAdapter.setBackoffTime(storageAdapter.getBackoffTime() - BACKOFF_POLL_INTERVAL)
-      if (storageAdapter.getBackoffTime() <= 0) {
-        log('backoff off')
-        clearInterval(backoffInterval)
-      }
-    }
+    storageAdapter.setBackoffTime(now() + INITIAL_BACKOFF_TIME * Math.pow(2, errorCount - 1))
+    log('backoff time:', storageAdapter.getBackoffTime() - now())
   }
 
   function activeQueueRunning () {

--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -2,7 +2,7 @@ var _ = require('underscore')
 var createLocalStorageAdapter = require('./local-storage-adapter')
 
 var QUEUE_POLL_INTERVAL = 100
-var ACTIVE_QUEUE_EXPIRE_TIME = 5000
+var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var DEFAULT_BATCH_SIZE = 20
 var INITIAL_BACKOFF_TIME = 1000
 var BACKOFF_POLL_INTERVAL = 1000
@@ -19,9 +19,20 @@ function createQueueThat (options) {
   var queueId = Math.random() + now()
   var processInterval, backoffInterval, queueIsSending = false
 
+  /**
+   * Check after ACTIVE_QUEUE_EXPIRE_TIME in case
+   * the previous page's queue has not expired yet.
+   */
+  var initialCheckTimer = setTimeout(function () {
+    if (!activeQueueRunning()) {
+      switchActiveQueue(queueId)
+    }
+  }, ACTIVE_QUEUE_EXPIRE_TIME)
+
   queueThat.destroy = function destroy () {
     clearInterval(processInterval)
     clearInterval(backoffInterval)
+    clearTimeout(initialCheckTimer)
   }
 
   return queueThat
@@ -35,7 +46,10 @@ function createQueueThat (options) {
       log('Item(s) sent to active queue')
       return
     }
+    switchActiveQueue(queueId)
+  }
 
+  function switchActiveQueue (queueId) {
     log('Switching to queue', queueId)
     clearInterval(processInterval)
     resumeBackoff()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "queue-that",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A queue managed in localStorage for async tasks that may run immediately before page unload.",
   "main": "lib/queue-that.js",
   "scripts": {

--- a/test/test-queue-that.js
+++ b/test/test-queue-that.js
@@ -5,7 +5,7 @@ var sinon = require('sinon')
 var proxyquire = require('proxyquireify-es3')(require)
 
 var QUEUE_POLL_INTERVAL = 100
-var ACTIVE_QUEUE_EXPIRE_TIME = 5000
+var ACTIVE_QUEUE_EXPIRE_TIME = 3000
 var INITIAL_BACKOFF_TIME = 1000
 
 describe('createQueueThat', function () {
@@ -95,6 +95,19 @@ describe('createQueueThat', function () {
         ts: now() - ACTIVE_QUEUE_EXPIRE_TIME
       })
       queueThat('A')
+      expect(adapter.setActiveQueue.callCount).to.be(1)
+    })
+
+    it('should check the active queue ACTIVE_QUEUE_EXPIRE_TIME after initialisation', function () {
+      adapter.getActiveQueue.returns({
+        id: 123,
+        ts: now() - ACTIVE_QUEUE_EXPIRE_TIME
+      })
+
+      clock.tick(ACTIVE_QUEUE_EXPIRE_TIME - 1)
+      expect(adapter.setActiveQueue.callCount).to.be(0)
+
+      clock.tick(1)
       expect(adapter.setActiveQueue.callCount).to.be(1)
     })
 

--- a/test/test-queue-that.js
+++ b/test/test-queue-that.js
@@ -268,7 +268,7 @@ describe('createQueueThat', function () {
     })
 
     it('should use localStorage as the back off timer', function () {
-      adapter.setBackoffTime(3000)
+      adapter.setBackoffTime(now() + 3000)
       adapter.setErrorCount(3)
       queueThat('A')
 
@@ -280,7 +280,7 @@ describe('createQueueThat', function () {
 
       options.process.getCall(0).args[1]('error')
       expect(adapter.setErrorCount.withArgs(4).callCount).to.be(1)
-      expect(adapter.setBackoffTime.withArgs(INITIAL_BACKOFF_TIME * Math.pow(2, 3)).callCount).to.be(1)
+      expect(adapter.setBackoffTime.withArgs(now() + INITIAL_BACKOFF_TIME * Math.pow(2, 3)).callCount).to.be(1)
 
       clock.tick(INITIAL_BACKOFF_TIME * Math.pow(2, 4) + QUEUE_POLL_INTERVAL)
       expect(options.process.callCount).to.be(2)
@@ -290,19 +290,20 @@ describe('createQueueThat', function () {
       expect(adapter.setErrorCount.withArgs(0).callCount).to.be(1)
     })
 
-    it('should not poll backoff when options.process succeeds', function () {
-      adapter.setBackoffTime(3000)
+    it('should not increment backoff when options.process succeeds', function () {
+      adapter.setBackoffTime(now() + 3000)
       adapter.setErrorCount(1)
+
       expect(adapter.setBackoffTime.callCount).to.be(1)
       queueThat('A')
       clock.tick(QUEUE_POLL_INTERVAL)
 
       clock.tick(3000 + QUEUE_POLL_INTERVAL)
-      expect(adapter.setBackoffTime.callCount).to.be(4)
+      expect(adapter.setBackoffTime.callCount).to.be(1)
       options.process.getCall(0).args[1]()
 
       clock.tick(INITIAL_BACKOFF_TIME * Math.pow(2, 6))
-      expect(adapter.setBackoffTime.callCount).to.be(4)
+      expect(adapter.setBackoffTime.callCount).to.be(1)
     })
   })
 })


### PR DESCRIPTION
Instead of polling the backoff time, just wait for the backoff date to expire and then resume processing.