### PR TITLE
Add a trim option to trim the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ var q = queueThat({
     when.all(
       items.map(post.bind(null, 'https://somewhere.com/events'))
     ).then(done)
+  },
+  /**
+   * Every time the queue is set, this setter will be called.
+   * Good for reducing the queue size if it gets too long.
+   */
+  trim: function (items) {
+    return items.filter(function (item) {
+      return item !== 'Low priority'
+    })
   }
 })
 
@@ -65,6 +74,9 @@ q({
 - The active queue polls localStorage every **100ms** for new tasks.
 - If the active queue does not poll for over **5 seconds**, the next tab to queue
   a process will become the active queue.
+- Falls back to `window.__queueThat__` variable if localStorage throws or doesn't work.
+- Optional trim function that will be called as a setter every time the queue is set. This is good for
+  when the queue is taking up a lot of localStorage or if JSON parsing/stringifying becomes slow.
 
 ### Support
 

--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -16,6 +16,7 @@ function createQueueThat (options) {
   }
   options.batchSize = options.batchSize || DEFAULT_BATCH_SIZE
   options.label = options.label || DEFAULT_QUEUE_LABEL
+  options.trim = options.trim || _.identity
 
   var processInterval
   var queueIsSending = false
@@ -48,7 +49,7 @@ function createQueueThat (options) {
   function queueThat (item) {
     var queue = storageAdapter.getQueue()
     queue.push(item)
-    storageAdapter.setQueue(queue)
+    storageAdapter.setQueue(options.trim(queue))
 
     if (activeQueueRunning()) {
       log('Item(s) sent to active queue')

--- a/test/functional/test-queue-that-functional.js
+++ b/test/functional/test-queue-that-functional.js
@@ -1,4 +1,5 @@
 /* global describe, it, expect, beforeEach, afterEach, sinon */
+var _ = require('underscore')
 var createQueueThat = require('../../lib/queue-that')
 
 describe('queueThat (functional)', function () {
@@ -210,5 +211,43 @@ describe('queueThat (functional)', function () {
         done()
       }
     }
+  })
+
+  it('should trim tasks', function (done) {
+    queueThat.options.trim = function (items) {
+      return _.filter(items, function (item) {
+        return item.task !== 'b'
+      })
+    }
+
+    queueThat.options.process = sinon.spy(function (items, next) {
+      expect(items).to.eql([{
+        task: 'a'
+      }, {
+        task: 'c'
+      }])
+      next()
+      done()
+    })
+
+    queueThat({
+      task: 'a'
+    })
+
+    queueThat({
+      task: 'b'
+    })
+
+    setTimeout(function () {
+      queueThat({
+        task: 'b'
+      })
+      queueThat({
+        task: 'b'
+      })
+      queueThat({
+        task: 'c'
+      })
+    }, 10)
   })
 })

--- a/test/test-queue-that.js
+++ b/test/test-queue-that.js
@@ -256,6 +256,29 @@ describe('createQueueThat', function () {
       expect(options.process.callCount).to.be(1)
     })
 
+    it('should allow a trim function option', function () {
+      options.trim = function (items) {
+        return _.filter(items, function (item) {
+          return item !== 'B'
+        })
+      }
+
+      queueThat('A')
+      queueThat('B')
+      queueThat('C')
+      queueThat('B')
+      queueThat('D')
+      queueThat('B')
+      queueThat('C')
+
+      expect(localStorageAdapter.getQueue()).to.eql(['A', 'C', 'D', 'C'])
+
+      clock.tick(QUEUE_POLL_INTERVAL)
+
+      expect(options.process.callCount).to.be(1)
+      expect(options.process.getCall(0).args[0]).to.eql(['A', 'C', 'D', 'C'])
+    })
+
     it('should backoff exponentially on process error', function () {
       localStorageAdapter.setQueue(_.range(4))
       queueThat('A')


### PR DESCRIPTION
- called as a setter every time the queue is set
- good for when the queue is taking up a lot of localStorage or if JSON parsing/stringifying becomes slow