### PR TITLE
Cache queue writing

### DIFF
--- a/lib/local-storage-adapter.js
+++ b/lib/local-storage-adapter.js
@@ -1,3 +1,4 @@
+var _ = require('underscore')
 var json = require('json-bourne')
 
 var QUEUE_KEY = '* - Queue'
@@ -13,6 +14,12 @@ function createLocalStorageAdapter (queueName) {
   var backoffTimeKey = BACKOFF_TIME_KEY.replace('*', queueName)
   var errorCountKey = ERROR_COUNT_KEY.replace('*', queueName)
 
+  var cacheInSync = false
+  var storageInSync = true
+  var queueCache = []
+
+  var flushOnDefer = _.debounce(flush, 0)
+
   var adapter = {
     getQueue: getQueue,
     setQueue: setQueue,
@@ -27,17 +34,34 @@ function createLocalStorageAdapter (queueName) {
     works: works,
     reset: reset,
     remove: remove,
-    type: 'localStorage'
+    type: 'localStorage',
+    flush: flush
   }
 
   return adapter
 
+  function flush () {
+    if (!storageInSync) {
+      adapter.save(queueKey, json.stringify(queueCache))
+      storageInSync = true
+      cacheInSync = false
+    }
+  }
+
   function getQueue () {
-    return json.parse(adapter.load(queueKey) || '[]')
+    if (!cacheInSync) {
+      queueCache = json.parse(adapter.load(queueKey) || '[]')
+      cacheInSync = true
+    }
+    return queueCache
   }
 
   function setQueue (queue) {
-    adapter.save(queueKey, json.stringify(queue))
+    queueCache = queue
+    storageInSync = false
+    cacheInSync = true
+
+    flushOnDefer()
   }
 
   function getErrorCount () {

--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -49,6 +49,7 @@ function createQueueThat (options) {
     clearInterval(processInterval)
     clearTimeout(initialCheckTimer)
   }
+  queueThat.flushQueueCache = queueThat.storageAdapter.flush
 
   return queueThat
 


### PR DESCRIPTION
- Multiple writes to the queue can be slow
- Wait for synchronous blocks of writes to be finished before writing
- Expose flush function to persist the queue if needed