### PR TITLE
Fix deferred get cache bug

### DIFF
--- a/lib/local-storage-adapter.js
+++ b/lib/local-storage-adapter.js
@@ -14,8 +14,8 @@ function createLocalStorageAdapter (queueName) {
   var backoffTimeKey = BACKOFF_TIME_KEY.replace('*', queueName)
   var errorCountKey = ERROR_COUNT_KEY.replace('*', queueName)
 
-  var cacheInSync = false
-  var storageInSync = true
+  var dirtyCache = true
+  var setPending = false
   var queueCache = []
 
   var flushOnDefer = _.debounce(flush, 0)
@@ -41,26 +41,26 @@ function createLocalStorageAdapter (queueName) {
   return adapter
 
   function flush () {
-    if (!storageInSync) {
+    dirtyCache = true
+    if (setPending) {
       adapter.save(queueKey, json.stringify(queueCache))
-      storageInSync = true
-      cacheInSync = false
+      setPending = false
     }
   }
 
   function getQueue () {
-    if (!cacheInSync) {
+    if (dirtyCache) {
       queueCache = json.parse(adapter.load(queueKey) || '[]')
-      cacheInSync = true
+      dirtyCache = false
+      flushOnDefer()
     }
     return queueCache
   }
 
   function setQueue (queue) {
     queueCache = queue
-    storageInSync = false
-    cacheInSync = true
-
+    dirtyCache = false
+    setPending = true
     flushOnDefer()
   }
 

--- a/test/test-global-variable-storage-adapter.js
+++ b/test/test-global-variable-storage-adapter.js
@@ -55,6 +55,14 @@ describe('globalVariableAdapter', function () {
       window.__queueThat__[QUEUE_KEY] = JSON.stringify(['other', 'thing'])
       expect(globalVariableAdapter.getQueue()).to.eql(['other', 'thing'])
     })
+    it('should get from  global variable after defer', function () {
+      clock.tick(10)
+      expect(globalVariableAdapter.getQueue()).to.eql(['a', 'b'])
+      window.__queueThat__[QUEUE_KEY] = JSON.stringify(['c', 'd'])
+      expect(globalVariableAdapter.getQueue()).to.eql(['a', 'b'])
+      clock.tick(10)
+      expect(globalVariableAdapter.getQueue()).to.eql(['c', 'd'])
+    })
   })
 
   describe('setQueue', function () {

--- a/test/test-local-storage-adapter.js
+++ b/test/test-local-storage-adapter.js
@@ -79,6 +79,14 @@ spec('localStorageAdapter', function () {
       localStorage[QUEUE_KEY] = JSON.stringify(['other', 'thing'])
       expect(localStorageAdapter.getQueue()).to.eql(['other', 'thing'])
     })
+    it('should get from localStorage after defer', function () {
+      clock.tick(10)
+      expect(localStorageAdapter.getQueue()).to.eql(['a', 'b'])
+      localStorage[QUEUE_KEY] = JSON.stringify(['c', 'd'])
+      expect(localStorageAdapter.getQueue()).to.eql(['a', 'b'])
+      clock.tick(10)
+      expect(localStorageAdapter.getQueue()).to.eql(['c', 'd'])
+    })
   })
 
   describe('setQueue', function () {


### PR DESCRIPTION
- Multiple sync gets should get from cache, after a defer they should get from storage
- Better naming of cache syncing variables
- This bug would cause pings added to the queue from tabs other than the active tab to be ignored until the active tab changes (due to a link click or reload)