### PR TITLE
containsRepeatedItems flag on item batch

### DIFF
--- a/lib/local-storage-adapter.js
+++ b/lib/local-storage-adapter.js
@@ -5,6 +5,7 @@ var QUEUE_KEY = '* - Queue'
 var ACTIVE_QUEUE_KEY = '* - Active Queue'
 var BACKOFF_TIME_KEY = '* - Backoff Time'
 var ERROR_COUNT_KEY = '* - Error Count'
+var QUEUE_PROCESSING_KEY = '* - Queue Processing'
 
 module.exports = createLocalStorageAdapter
 
@@ -13,6 +14,7 @@ function createLocalStorageAdapter (queueName) {
   var activeQueueKey = ACTIVE_QUEUE_KEY.replace('*', queueName)
   var backoffTimeKey = BACKOFF_TIME_KEY.replace('*', queueName)
   var errorCountKey = ERROR_COUNT_KEY.replace('*', queueName)
+  var queueProcessingKey = QUEUE_PROCESSING_KEY.replace('*', queueName)
 
   var dirtyCache = true
   var setPending = false
@@ -30,6 +32,8 @@ function createLocalStorageAdapter (queueName) {
     getActiveQueue: getActiveQueue,
     setActiveQueue: setActiveQueue,
     clearActiveQueue: clearActiveQueue,
+    getQueueProcessing: getQueueProcessing,
+    setQueueProcessing: setQueueProcessing,
     save: save,
     load: load,
     works: works,
@@ -99,6 +103,14 @@ function createLocalStorageAdapter (queueName) {
 
   function clearActiveQueue () {
     adapter.remove(activeQueueKey)
+  }
+
+  function getQueueProcessing () {
+    return Boolean(Number(adapter.load(queueProcessingKey)))
+  }
+
+  function setQueueProcessing (isProcessing) {
+    adapter.save(queueProcessingKey, Number(isProcessing))
   }
 
   function works () {

--- a/lib/queue-that.js
+++ b/lib/queue-that.js
@@ -23,7 +23,7 @@ function createQueueThat (options) {
   options.backoffTime = options.backoffTime || BACKOFF_TIME
 
   var processInterval
-  var queueIsSending = false
+  var queueIsProcessing = false
   var queueId = Math.random() + now()
 
   var storageAdapter = createLocalStorageAdapter(options.label)
@@ -50,7 +50,7 @@ function createQueueThat (options) {
   queueThat.flushQueueCache = queueThat.storageAdapter.flush
   deactivateOnUnload(queueId)
 
-  log.info('Initialized with queue ID' + queueId)
+  log.info('Initialized with queue ID ' + queueId)
   return queueThat
 
   function queueThat (item) {
@@ -73,7 +73,7 @@ function createQueueThat (options) {
   function processQueue () {
     storageAdapter.setActiveQueue(queueId)
 
-    if (queueIsSending) {
+    if (queueIsProcessing) {
       return
     }
     if (storageAdapter.getBackoffTime() > now()) {
@@ -85,11 +85,18 @@ function createQueueThat (options) {
       return
     }
 
+    batch.containsRepeatedItems = storageAdapter.getQueueProcessing()
+
     log.info('Processing queue batch of ' + batch.length + ' items')
+
+    if (batch.containsRepeatedItems) log.info('Batch contains repeated items')
+    else log.info('Batch does not contain repeated items')
+
     var itemsProcessing = batch.length
-    queueIsSending = true
+    queueIsProcessing = true
+
     options.process(batch, function (err) {
-      queueIsSending = false
+      queueIsProcessing = false
       if (err) {
         processError(err)
         return
@@ -97,8 +104,15 @@ function createQueueThat (options) {
       storageAdapter.setErrorCount(0)
       var queue = _.rest(storageAdapter.getQueue(), itemsProcessing)
       storageAdapter.setQueue(queue)
+
+      storageAdapter.setQueueProcessing(false)
+      storageAdapter.flush()
+
       log.info('Queue processed, ' + queue.length + ' remaining items')
     })
+
+    storageAdapter.setQueueProcessing(true)
+    storageAdapter.flush()
   }
 
   function processError (err) {

--- a/test/test-global-variable-storage-adapter.js
+++ b/test/test-global-variable-storage-adapter.js
@@ -11,6 +11,7 @@ describe('globalVariableAdapter', function () {
   var ACTIVE_QUEUE_KEY
   var BACKOFF_TIME_KEY
   var ERROR_COUNT_KEY
+  var QUEUE_PROCESSING_KEY
 
   beforeEach(function () {
     clock = sinon.useFakeTimers()
@@ -22,6 +23,7 @@ describe('globalVariableAdapter', function () {
     ACTIVE_QUEUE_KEY = 'Some Name - Active Queue'
     BACKOFF_TIME_KEY = 'Some Name - Backoff Time'
     ERROR_COUNT_KEY = 'Some Name - Error Count'
+    QUEUE_PROCESSING_KEY = 'Some Name - Queue Processing'
   })
 
   afterEach(function () {
@@ -157,6 +159,30 @@ describe('globalVariableAdapter', function () {
         id: 'the active queue id',
         ts: now()
       })
+    })
+  })
+
+  describe('getQueueProcessing', function () {
+    it('should be false by default', function () {
+      expect(globalVariableAdapter.getQueueProcessing()).to.be(false)
+    })
+
+    it('should parse numeric string to boolean', function () {
+      window.__queueThat__[QUEUE_PROCESSING_KEY] = '0'
+      expect(globalVariableAdapter.getQueueProcessing()).to.be(false)
+
+      window.__queueThat__[QUEUE_PROCESSING_KEY] = '1'
+      expect(globalVariableAdapter.getQueueProcessing()).to.be(true)
+    })
+  })
+
+  describe('setQueueProcessing', function () {
+    it('should encode a boolean as a numeric string', function () {
+      globalVariableAdapter.setQueueProcessing(false)
+      expect(window.__queueThat__[QUEUE_PROCESSING_KEY]).to.be('0')
+
+      globalVariableAdapter.setQueueProcessing(true)
+      expect(window.__queueThat__[QUEUE_PROCESSING_KEY]).to.be('1')
     })
   })
 })

--- a/test/test-local-storage-adapter.js
+++ b/test/test-local-storage-adapter.js
@@ -19,6 +19,7 @@ spec('localStorageAdapter', function () {
   var ACTIVE_QUEUE_KEY
   var BACKOFF_TIME_KEY
   var ERROR_COUNT_KEY
+  var QUEUE_PROCESSING_KEY
 
   beforeEach(function () {
     clock = sinon.useFakeTimers()
@@ -27,6 +28,7 @@ spec('localStorageAdapter', function () {
     ACTIVE_QUEUE_KEY = 'Some Name - Active Queue'
     BACKOFF_TIME_KEY = 'Some Name - Backoff Time'
     ERROR_COUNT_KEY = 'Some Name - Error Count'
+    QUEUE_PROCESSING_KEY = 'Some Name - Queue Processing'
   })
 
   afterEach(function () {
@@ -181,6 +183,30 @@ spec('localStorageAdapter', function () {
         id: 'the active queue id',
         ts: now()
       })
+    })
+  })
+
+  describe('getQueueProcessing', function () {
+    it('should be false by default', function () {
+      expect(localStorageAdapter.getQueueProcessing()).to.be(false)
+    })
+
+    it('should parse numeric string to boolean', function () {
+      localStorage[QUEUE_PROCESSING_KEY] = '0'
+      expect(localStorageAdapter.getQueueProcessing()).to.be(false)
+
+      localStorage[QUEUE_PROCESSING_KEY] = '1'
+      expect(localStorageAdapter.getQueueProcessing()).to.be(true)
+    })
+  })
+
+  describe('setQueueProcessing', function () {
+    it('should encode a boolean as a numeric string', function () {
+      localStorageAdapter.setQueueProcessing(false)
+      expect(localStorage[QUEUE_PROCESSING_KEY]).to.be('0')
+
+      localStorageAdapter.setQueueProcessing(true)
+      expect(localStorage[QUEUE_PROCESSING_KEY]).to.be('1')
     })
   })
 })


### PR DESCRIPTION
- When calling `options.process`, a `containsRepeatedItems` property is available on the item array to specify whether it may contain items that were processed but returned an error or didn't get a callback
- Queue That now assumes `options.process` is asynchronous, i.e. the `options.process` function must defer the done callback else `containsRepeatedItems` may be incorrect